### PR TITLE
feat(compliance): add database schema for security compliance

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -53,5 +53,8 @@
 	},
 	"engines": {
 		"node": ">=18.0.0"
+	},
+	"prisma": {
+		"seed": "node prisma/seed.js"
 	}
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,14 +22,14 @@ model dashboard_preferences {
 }
 
 model host_groups {
-  id                      String                    @id
-  name                    String                    @unique
-  description             String?
-  color                   String?                   @default("#3B82F6")
-  created_at              DateTime                  @default(now())
-  updated_at              DateTime
-  host_group_memberships  host_group_memberships[]
-  auto_enrollment_tokens  auto_enrollment_tokens[]
+  id                     String                   @id
+  name                   String                   @unique
+  description            String?
+  color                  String?                  @default("#3B82F6")
+  created_at             DateTime                 @default(now())
+  updated_at             DateTime
+  host_group_memberships host_group_memberships[]
+  auto_enrollment_tokens auto_enrollment_tokens[]
 }
 
 model host_group_memberships {
@@ -81,46 +81,47 @@ model host_repositories {
 }
 
 model hosts {
-  id                      String                    @id
-  machine_id              String?
-  friendly_name           String
-  ip                      String?
-  os_type                 String
-  os_version              String
-  architecture            String?
-  last_update             DateTime                  @default(now())
-  status                  String                    @default("active")
-  created_at              DateTime                  @default(now())
-  updated_at              DateTime
-  api_id                  String                    @unique
-  api_key                 String                    @unique
-  agent_version           String?
-  auto_update             Boolean                   @default(true)
-  cpu_cores               Int?
-  cpu_model               String?
-  disk_details            Json?
-  dns_servers             Json?
-  gateway_ip              String?
-  hostname                String?
-  kernel_version          String?
+  id                       String                   @id
+  machine_id               String?
+  friendly_name            String
+  ip                       String?
+  os_type                  String
+  os_version               String
+  architecture             String?
+  last_update              DateTime                 @default(now())
+  status                   String                   @default("active")
+  created_at               DateTime                 @default(now())
+  updated_at               DateTime
+  api_id                   String                   @unique
+  api_key                  String                   @unique
+  agent_version            String?
+  auto_update              Boolean                  @default(true)
+  cpu_cores                Int?
+  cpu_model                String?
+  disk_details             Json?
+  dns_servers              Json?
+  gateway_ip               String?
+  hostname                 String?
+  kernel_version           String?
   installed_kernel_version String?
   load_average             Json?
-  network_interfaces      Json?
-  ram_installed           Int?
-  selinux_status          String?
-  swap_size               Int?
-  system_uptime           String?
-  notes                   String?
-  needs_reboot            Boolean?                  @default(false)
-  reboot_reason           String?
-  docker_enabled          Boolean                   @default(false)
-  host_packages           host_packages[]
-  host_repositories       host_repositories[]
-  host_group_memberships  host_group_memberships[]
-  update_history          update_history[]
-  job_history             job_history[]
-  docker_volumes          docker_volumes[]
-  docker_networks         docker_networks[]
+  network_interfaces       Json?
+  ram_installed            Int?
+  selinux_status           String?
+  swap_size                Int?
+  system_uptime            String?
+  notes                    String?
+  needs_reboot             Boolean?                 @default(false)
+  reboot_reason            String?
+  docker_enabled           Boolean                  @default(false)
+  host_packages            host_packages[]
+  host_repositories        host_repositories[]
+  host_group_memberships   host_group_memberships[]
+  update_history           update_history[]
+  job_history              job_history[]
+  docker_volumes           docker_volumes[]
+  docker_networks          docker_networks[]
+  compliance_scans         compliance_scans[]
 
   @@index([machine_id])
   @@index([friendly_name])
@@ -178,38 +179,38 @@ model role_permissions {
 }
 
 model settings {
-  id                     String    @id
-  server_url             String    @default("http://localhost:3001")
-  server_protocol        String    @default("http")
-  server_host            String    @default("localhost")
-  server_port            Int       @default(3001)
-  created_at             DateTime  @default(now())
-  updated_at             DateTime
-  update_interval        Int       @default(60)
-  auto_update            Boolean   @default(false)
-  github_repo_url        String    @default("https://github.com/PatchMon/PatchMon.git")
-  ssh_key_path           String?
-  repository_type        String    @default("public")
-  last_update_check      DateTime?
-  latest_version         String?
-  update_available       Boolean   @default(false)
-  signup_enabled         Boolean   @default(false)
-  default_user_role      String    @default("user")
-  ignore_ssl_self_signed Boolean   @default(false)
-  logo_dark              String?   @default("/assets/logo_dark.png")
-  logo_light             String?   @default("/assets/logo_light.png")
-  favicon                String?   @default("/assets/logo_square.svg")
-  metrics_enabled        Boolean   @default(true)
-  metrics_anonymous_id   String?
-  metrics_last_sent      DateTime?
-  show_github_version_on_login Boolean @default(true)
+  id                           String    @id
+  server_url                   String    @default("http://localhost:3001")
+  server_protocol              String    @default("http")
+  server_host                  String    @default("localhost")
+  server_port                  Int       @default(3001)
+  created_at                   DateTime  @default(now())
+  updated_at                   DateTime
+  update_interval              Int       @default(60)
+  auto_update                  Boolean   @default(false)
+  github_repo_url              String    @default("https://github.com/PatchMon/PatchMon.git")
+  ssh_key_path                 String?
+  repository_type              String    @default("public")
+  last_update_check            DateTime?
+  latest_version               String?
+  update_available             Boolean   @default(false)
+  signup_enabled               Boolean   @default(false)
+  default_user_role            String    @default("user")
+  ignore_ssl_self_signed       Boolean   @default(false)
+  logo_dark                    String?   @default("/assets/logo_dark.png")
+  logo_light                   String?   @default("/assets/logo_light.png")
+  favicon                      String?   @default("/assets/logo_square.svg")
+  metrics_enabled              Boolean   @default(true)
+  metrics_anonymous_id         String?
+  metrics_last_sent            DateTime?
+  show_github_version_on_login Boolean   @default(true)
 }
 
 model update_history {
   id              String   @id
   host_id         String
   packages_count  Int
-  security_count   Int
+  security_count  Int
   total_packages  Int?
   payload_size_kb Float?
   execution_time  Float?
@@ -232,49 +233,49 @@ model system_statistics {
 }
 
 model users {
-  id                     String                   @id
-  username               String                   @unique
-  email                  String                   @unique
-  password_hash          String?
-  role                   String                   @default("admin")
-  is_active              Boolean                  @default(true)
-  last_login             DateTime?
-  created_at             DateTime                 @default(now())
-  updated_at             DateTime
-  tfa_backup_codes       String?
-  tfa_enabled            Boolean                  @default(false)
-  tfa_secret             String?
-  first_name             String?
-  last_name              String?
-  theme_preference       String?                  @default("dark")
-  color_theme            String?                  @default("cyber_blue")
-  oidc_sub               String?                  @unique
-  oidc_provider          String?
-  dashboard_preferences  dashboard_preferences[]
-  user_sessions          user_sessions[]
-  auto_enrollment_tokens auto_enrollment_tokens[]
+  id                        String                      @id
+  username                  String                      @unique
+  email                     String                      @unique
+  password_hash             String?
+  role                      String                      @default("admin")
+  is_active                 Boolean                     @default(true)
+  last_login                DateTime?
+  created_at                DateTime                    @default(now())
+  updated_at                DateTime
+  tfa_backup_codes          String?
+  tfa_enabled               Boolean                     @default(false)
+  tfa_secret                String?
+  first_name                String?
+  last_name                 String?
+  theme_preference          String?                     @default("dark")
+  color_theme               String?                     @default("cyber_blue")
+  oidc_sub                  String?                     @unique
+  oidc_provider             String?
+  dashboard_preferences     dashboard_preferences[]
+  user_sessions             user_sessions[]
+  auto_enrollment_tokens    auto_enrollment_tokens[]
   release_notes_acceptances release_notes_acceptances[]
 
   @@index([role])
 }
 
 model user_sessions {
-  id                String   @id
-  user_id           String
-  refresh_token     String   @unique
-  access_token_hash String?
-  ip_address        String?
-  user_agent        String?
+  id                 String    @id
+  user_id            String
+  refresh_token      String    @unique
+  access_token_hash  String?
+  ip_address         String?
+  user_agent         String?
   device_fingerprint String?
-  last_activity     DateTime @default(now())
-  expires_at        DateTime
-  created_at        DateTime @default(now())
-  is_revoked        Boolean  @default(false)
-  tfa_remember_me   Boolean  @default(false)
-  tfa_bypass_until  DateTime?
-  login_count       Int      @default(1)
-  last_login_ip     String?
-  users             users    @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  last_activity      DateTime  @default(now())
+  expires_at         DateTime
+  created_at         DateTime  @default(now())
+  is_revoked         Boolean   @default(false)
+  tfa_remember_me    Boolean   @default(false)
+  tfa_bypass_until   DateTime?
+  login_count        Int       @default(1)
+  last_login_ip      String?
+  users              users     @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@index([user_id])
   @@index([refresh_token])
@@ -309,21 +310,21 @@ model auto_enrollment_tokens {
 }
 
 model docker_containers {
-  id                String              @id
-  host_id           String
-  container_id      String
-  name              String
-  image_id          String?
-  image_name        String
-  image_tag         String              @default("latest")
-  status            String
-  state             String?
-  ports             Json?
-  created_at        DateTime
-  started_at        DateTime?
-  updated_at        DateTime
-  last_checked      DateTime            @default(now())
-  docker_images     docker_images?      @relation(fields: [image_id], references: [id], onDelete: SetNull)
+  id            String         @id
+  host_id       String
+  container_id  String
+  name          String
+  image_id      String?
+  image_name    String
+  image_tag     String         @default("latest")
+  status        String
+  state         String?
+  ports         Json?
+  created_at    DateTime
+  started_at    DateTime?
+  updated_at    DateTime
+  last_checked  DateTime       @default(now())
+  docker_images docker_images? @relation(fields: [image_id], references: [id], onDelete: SetNull)
 
   @@unique([host_id, container_id])
   @@index([host_id])
@@ -333,18 +334,18 @@ model docker_containers {
 }
 
 model docker_images {
-  id                 String                 @id
-  repository         String
-  tag                String                 @default("latest")
-  image_id           String
-  digest             String?
-  size_bytes         BigInt?
-  source             String                 @default("docker-hub")
-  created_at         DateTime
-  last_pulled        DateTime?
-  last_checked       DateTime               @default(now())
-  updated_at         DateTime
-  docker_containers  docker_containers[]
+  id                   String                 @id
+  repository           String
+  tag                  String                 @default("latest")
+  image_id             String
+  digest               String?
+  size_bytes           BigInt?
+  source               String                 @default("docker-hub")
+  created_at           DateTime
+  last_pulled          DateTime?
+  last_checked         DateTime               @default(now())
+  updated_at           DateTime
+  docker_containers    docker_containers[]
   docker_image_updates docker_image_updates[]
 
   @@unique([repository, tag, image_id])
@@ -354,16 +355,16 @@ model docker_images {
 }
 
 model docker_image_updates {
-  id                String        @id
-  image_id          String
-  current_tag       String
-  available_tag     String
-  is_security_update Boolean      @default(false)
-  severity          String?
-  changelog_url     String?
-  created_at        DateTime      @default(now())
-  updated_at        DateTime
-  docker_images     docker_images @relation(fields: [image_id], references: [id], onDelete: Cascade)
+  id                 String        @id
+  image_id           String
+  current_tag        String
+  available_tag      String
+  is_security_update Boolean       @default(false)
+  severity           String?
+  changelog_url      String?
+  created_at         DateTime      @default(now())
+  updated_at         DateTime
+  docker_images      docker_images @relation(fields: [image_id], references: [id], onDelete: Cascade)
 
   @@unique([image_id, available_tag])
   @@index([image_id])
@@ -371,22 +372,22 @@ model docker_image_updates {
 }
 
 model docker_volumes {
-  id          String   @id
-  host_id     String
-  volume_id   String
-  name        String
-  driver      String
-  mountpoint  String?
-  renderer    String?
-  scope       String   @default("local")
-  labels      Json?
-  options     Json?
-  size_bytes  BigInt?
-  ref_count   Int      @default(0)
-  created_at  DateTime
-  updated_at  DateTime
+  id           String   @id
+  host_id      String
+  volume_id    String
+  name         String
+  driver       String
+  mountpoint   String?
+  renderer     String?
+  scope        String   @default("local")
+  labels       Json?
+  options      Json?
+  size_bytes   BigInt?
+  ref_count    Int      @default(0)
+  created_at   DateTime
+  updated_at   DateTime
   last_checked DateTime @default(now())
-  hosts       hosts    @relation(fields: [host_id], references: [id], onDelete: Cascade)
+  hosts        hosts    @relation(fields: [host_id], references: [id], onDelete: Cascade)
 
   @@unique([host_id, volume_id])
   @@index([host_id])
@@ -395,24 +396,24 @@ model docker_volumes {
 }
 
 model docker_networks {
-  id             String   @id
-  host_id        String
-  network_id     String
-  name           String
-  driver         String
-  scope          String   @default("local")
-  ipv6_enabled   Boolean  @default(false)
-  internal       Boolean  @default(false)
-  attachable     Boolean  @default(true)
-  ingress        Boolean  @default(false)
-  config_only    Boolean  @default(false)
-  labels         Json?
-  ipam           Json?    // IPAM configuration (driver, config, options)
-  container_count Int     @default(0)
-  created_at     DateTime?
-  updated_at     DateTime
-  last_checked   DateTime @default(now())
-  hosts          hosts    @relation(fields: [host_id], references: [id], onDelete: Cascade)
+  id              String    @id
+  host_id         String
+  network_id      String
+  name            String
+  driver          String
+  scope           String    @default("local")
+  ipv6_enabled    Boolean   @default(false)
+  internal        Boolean   @default(false)
+  attachable      Boolean   @default(true)
+  ingress         Boolean   @default(false)
+  config_only     Boolean   @default(false)
+  labels          Json?
+  ipam            Json? // IPAM configuration (driver, config, options)
+  container_count Int       @default(0)
+  created_at      DateTime?
+  updated_at      DateTime
+  last_checked    DateTime  @default(now())
+  hosts           hosts     @relation(fields: [host_id], references: [id], onDelete: Cascade)
 
   @@unique([host_id, network_id])
   @@index([host_id])
@@ -421,20 +422,20 @@ model docker_networks {
 }
 
 model job_history {
-  id            String   @id
-  job_id        String
-  queue_name    String
-  job_name      String
-  host_id       String?
-  api_id        String?
-  status        String
-  attempt_number Int     @default(1)
-  error_message String?
-  output        Json?
-  created_at    DateTime @default(now())
-  updated_at    DateTime
-  completed_at  DateTime?
-  hosts         hosts?   @relation(fields: [host_id], references: [id], onDelete: SetNull)
+  id             String    @id
+  job_id         String
+  queue_name     String
+  job_name       String
+  host_id        String?
+  api_id         String?
+  status         String
+  attempt_number Int       @default(1)
+  error_message  String?
+  output         Json?
+  created_at     DateTime  @default(now())
+  updated_at     DateTime
+  completed_at   DateTime?
+  hosts          hosts?    @relation(fields: [host_id], references: [id], onDelete: SetNull)
 
   @@index([job_id])
   @@index([queue_name])
@@ -445,11 +446,11 @@ model job_history {
 }
 
 model release_notes_acceptances {
-  id         String   @id @default(uuid())
-  user_id    String
-  version    String
+  id          String   @id @default(uuid())
+  user_id     String
+  version     String
   accepted_at DateTime @default(now())
-  users      users    @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  users       users    @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@unique([user_id, version])
   @@index([user_id])
@@ -464,7 +465,7 @@ model audit_logs {
   ip_address     String?
   user_agent     String?
   request_id     String?
-  details        String?  // JSON stringified details
+  details        String? // JSON stringified details
   success        Boolean  @default(true)
   created_at     DateTime @default(now())
 
@@ -473,4 +474,93 @@ model audit_logs {
   @@index([target_user_id])
   @@index([created_at])
   @@index([success])
+}
+
+// ==========================================
+// Security Compliance Models
+// ==========================================
+
+model compliance_profiles {
+  id          String   @id @default(uuid())
+  name        String   @unique
+  type        String // "openscap" or "docker-bench"
+  os_family   String? // "ubuntu", "rhel", "debian", null for docker
+  version     String?
+  description String?
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  compliance_scans compliance_scans[]
+  compliance_rules compliance_rules[]
+
+  @@index([type])
+  @@index([os_family])
+}
+
+model compliance_scans {
+  id           String    @id @default(uuid())
+  host_id      String
+  profile_id   String
+  started_at   DateTime
+  completed_at DateTime?
+  status       String // "running", "completed", "failed"
+  total_rules  Int       @default(0)
+  passed       Int       @default(0)
+  failed       Int       @default(0)
+  warnings     Int       @default(0)
+  skipped      Int       @default(0)
+  score        Float? // Percentage 0-100
+  raw_output   String?   @db.Text
+  created_at   DateTime  @default(now())
+
+  hosts               hosts                @relation(fields: [host_id], references: [id], onDelete: Cascade)
+  compliance_profiles compliance_profiles  @relation(fields: [profile_id], references: [id], onDelete: Cascade)
+  compliance_results  compliance_results[]
+
+  @@index([host_id])
+  @@index([profile_id])
+  @@index([status])
+  @@index([started_at])
+  @@index([host_id, started_at])
+  @@index([host_id, profile_id])
+}
+
+model compliance_rules {
+  id          String  @id @default(uuid())
+  profile_id  String
+  rule_ref    String // Original rule ID from CIS/OpenSCAP
+  title       String
+  description String? @db.Text
+  rationale   String? @db.Text
+  severity    String? // "low", "medium", "high", "critical"
+  section     String? // CIS section number (e.g., "1.1.1")
+  remediation String? @db.Text
+
+  compliance_profiles compliance_profiles  @relation(fields: [profile_id], references: [id], onDelete: Cascade)
+  compliance_results  compliance_results[]
+
+  @@unique([profile_id, rule_ref])
+  @@index([profile_id])
+  @@index([severity])
+  @@index([section])
+}
+
+model compliance_results {
+  id          String   @id @default(uuid())
+  scan_id     String
+  rule_id     String
+  status      String // "pass", "fail", "warn", "skip", "notapplicable", "error"
+  finding     String?  @db.Text
+  actual      String?  @db.Text
+  expected    String?  @db.Text
+  remediation String?  @db.Text
+  created_at  DateTime @default(now())
+
+  compliance_scans compliance_scans @relation(fields: [scan_id], references: [id], onDelete: Cascade)
+  compliance_rules compliance_rules @relation(fields: [rule_id], references: [id], onDelete: Cascade)
+
+  @@index([scan_id])
+  @@index([rule_id])
+  @@index([status])
+  @@index([scan_id, status])
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,0 +1,11 @@
+const { seedComplianceProfiles } = require("./seeds/compliance-profiles");
+
+async function main() {
+  await seedComplianceProfiles();
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/backend/prisma/seeds/compliance-profiles.js
+++ b/backend/prisma/seeds/compliance-profiles.js
@@ -1,0 +1,89 @@
+const { PrismaClient } = require("@prisma/client");
+
+const prisma = new PrismaClient();
+
+const defaultProfiles = [
+  {
+    name: "CIS Ubuntu 22.04 L1",
+    type: "openscap",
+    os_family: "ubuntu",
+    version: "1.0.0",
+    description: "CIS Benchmark for Ubuntu 22.04 LTS - Level 1 Server",
+  },
+  {
+    name: "CIS Ubuntu 22.04 L2",
+    type: "openscap",
+    os_family: "ubuntu",
+    version: "1.0.0",
+    description: "CIS Benchmark for Ubuntu 22.04 LTS - Level 2 Server",
+  },
+  {
+    name: "CIS Ubuntu 20.04 L1",
+    type: "openscap",
+    os_family: "ubuntu",
+    version: "1.1.0",
+    description: "CIS Benchmark for Ubuntu 20.04 LTS - Level 1 Server",
+  },
+  {
+    name: "CIS RHEL 8 L1",
+    type: "openscap",
+    os_family: "rhel",
+    version: "2.0.0",
+    description: "CIS Benchmark for Red Hat Enterprise Linux 8 - Level 1 Server",
+  },
+  {
+    name: "CIS RHEL 8 L2",
+    type: "openscap",
+    os_family: "rhel",
+    version: "2.0.0",
+    description: "CIS Benchmark for Red Hat Enterprise Linux 8 - Level 2 Server",
+  },
+  {
+    name: "CIS Debian 11 L1",
+    type: "openscap",
+    os_family: "debian",
+    version: "1.0.0",
+    description: "CIS Benchmark for Debian 11 - Level 1 Server",
+  },
+  {
+    name: "CIS Docker",
+    type: "docker-bench",
+    os_family: null,
+    version: "1.5.0",
+    description: "CIS Docker Benchmark v1.5.0",
+  },
+];
+
+async function seedComplianceProfiles() {
+  console.log("Seeding compliance profiles...");
+
+  for (const profile of defaultProfiles) {
+    await prisma.compliance_profiles.upsert({
+      where: { name: profile.name },
+      update: {
+        type: profile.type,
+        os_family: profile.os_family,
+        version: profile.version,
+        description: profile.description,
+      },
+      create: profile,
+    });
+    console.log(`  Created/updated profile: ${profile.name}`);
+  }
+
+  console.log("Compliance profiles seeded successfully!");
+}
+
+module.exports = { seedComplianceProfiles };
+
+// Run directly if called as script
+if (require.main === module) {
+  seedComplianceProfiles()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}


### PR DESCRIPTION
## Summary
- Add compliance_profiles, compliance_scans, compliance_rules, and compliance_results tables for security compliance feature
- Add relationship from hosts table to compliance_scans
- Create seed data for default CIS benchmark profiles (Ubuntu 22.04/20.04, RHEL 8, Debian 11, Docker)
- Configure Prisma seed script for populating default profiles

## Changes
- `backend/prisma/schema.prisma`: Added 4 new models with appropriate indexes and relations
- `backend/prisma/seed.js`: Main seed orchestration file
- `backend/prisma/seeds/compliance-profiles.js`: Default compliance profiles seed data
- `backend/package.json`: Added prisma seed configuration

## Test plan
- [ ] Run `npx prisma validate` to verify schema syntax
- [ ] Run `npx prisma migrate dev --name add_security_compliance_tables` to create migration
- [ ] Run `npx prisma db seed` to seed default profiles
- [ ] Verify all 7 default profiles are created in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)