### PR TITLE
feat(compliance): add backend API for security compliance

### DIFF
--- a/backend/__tests__/routes/complianceRoutes.test.js
+++ b/backend/__tests__/routes/complianceRoutes.test.js
@@ -1,0 +1,436 @@
+/**
+ * Unit tests for Compliance Routes
+ */
+
+const express = require("express");
+const request = require("supertest");
+
+// Mock dependencies before requiring routes
+jest.mock("../../src/config/prisma");
+jest.mock("../../src/middleware/auth");
+jest.mock("../../src/services/agentWs");
+jest.mock("uuid");
+
+const { getPrismaClient } = require("../../src/config/prisma");
+const { authenticateToken } = require("../../src/middleware/auth");
+const agentWs = require("../../src/services/agentWs");
+const { v4: uuidv4 } = require("uuid");
+
+// Setup default mock implementations
+const mockPrisma = {
+  hosts: {
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+    count: jest.fn(),
+  },
+  compliance_profiles: {
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    create: jest.fn(),
+  },
+  compliance_scans: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    count: jest.fn(),
+  },
+  compliance_rules: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+  },
+  compliance_results: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+  },
+  $queryRaw: jest.fn(),
+};
+
+getPrismaClient.mockReturnValue(mockPrisma);
+uuidv4.mockReturnValue("mock-uuid");
+
+// Mock authenticateToken to pass through
+authenticateToken.mockImplementation((req, res, next) => {
+  req.user = { id: "user-123", role: "admin" };
+  next();
+});
+
+// Create test app
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+
+  const complianceRoutes = require("../../src/routes/complianceRoutes");
+  app.use("/api/v1/compliance", complianceRoutes);
+
+  return app;
+}
+
+describe("Compliance Routes", () => {
+  let app;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = createTestApp();
+  });
+
+  describe("POST /api/v1/compliance/scans", () => {
+    const mockHost = {
+      id: "host-123",
+      api_id: "test-api-id",
+      api_key: "test-api-key",
+      friendly_name: "Test Host",
+      hostname: "test-host",
+    };
+
+    const mockProfile = {
+      id: "profile-123",
+      name: "CIS Level 1",
+      type: "openscap",
+    };
+
+    const mockScan = {
+      id: "scan-123",
+      host_id: "host-123",
+      profile_id: "profile-123",
+      score: 85.0,
+    };
+
+    beforeEach(() => {
+      mockPrisma.hosts.findFirst.mockResolvedValue(mockHost);
+      mockPrisma.compliance_profiles.findFirst.mockResolvedValue(mockProfile);
+      mockPrisma.compliance_scans.create.mockResolvedValue(mockScan);
+      mockPrisma.compliance_rules.findFirst.mockResolvedValue(null);
+      mockPrisma.compliance_rules.create.mockResolvedValue({
+        id: "rule-123",
+        profile_id: "profile-123",
+        rule_ref: "test-rule",
+        title: "Test Rule",
+      });
+      mockPrisma.compliance_results.create.mockResolvedValue({});
+    });
+
+    it("should accept scan results with valid API credentials", async () => {
+      const response = await request(app)
+        .post("/api/v1/compliance/scans")
+        .set("X-API-ID", "test-api-id")
+        .set("X-API-KEY", "test-api-key")
+        .send({
+          profile_name: "CIS Level 1",
+          profile_type: "openscap",
+          results: [
+            { rule_ref: "test-rule", status: "pass", title: "Test Rule" },
+          ],
+        })
+        .expect(200);
+
+      expect(response.body.message).toBe("Scan results saved successfully");
+      expect(response.body.scan_id).toBeDefined();
+      expect(mockPrisma.compliance_scans.create).toHaveBeenCalled();
+    });
+
+    it("should reject without API credentials", async () => {
+      const response = await request(app)
+        .post("/api/v1/compliance/scans")
+        .send({
+          profile_name: "CIS Level 1",
+          results: [],
+        })
+        .expect(401);
+
+      expect(response.body.error).toBe("API credentials required");
+    });
+
+    it("should reject with invalid API credentials", async () => {
+      mockPrisma.hosts.findFirst.mockResolvedValue(null);
+
+      const response = await request(app)
+        .post("/api/v1/compliance/scans")
+        .set("X-API-ID", "invalid-id")
+        .set("X-API-KEY", "invalid-key")
+        .send({
+          profile_name: "CIS Level 1",
+          results: [],
+        })
+        .expect(401);
+
+      expect(response.body.error).toBe("Invalid API credentials");
+    });
+
+    it("should create a new profile if it does not exist", async () => {
+      mockPrisma.compliance_profiles.findFirst.mockResolvedValue(null);
+      mockPrisma.compliance_profiles.create.mockResolvedValue(mockProfile);
+
+      await request(app)
+        .post("/api/v1/compliance/scans")
+        .set("X-API-ID", "test-api-id")
+        .set("X-API-KEY", "test-api-key")
+        .send({
+          profile_name: "New Profile",
+          profile_type: "docker-bench",
+          results: [],
+        })
+        .expect(200);
+
+      expect(mockPrisma.compliance_profiles.create).toHaveBeenCalled();
+    });
+
+    it("should calculate correct stats from results", async () => {
+      const results = [
+        { rule_ref: "rule1", status: "pass", title: "Rule 1" },
+        { rule_ref: "rule2", status: "pass", title: "Rule 2" },
+        { rule_ref: "rule3", status: "fail", title: "Rule 3" },
+        { rule_ref: "rule4", status: "warn", title: "Rule 4" },
+        { rule_ref: "rule5", status: "skip", title: "Rule 5" },
+      ];
+
+      const response = await request(app)
+        .post("/api/v1/compliance/scans")
+        .set("X-API-ID", "test-api-id")
+        .set("X-API-KEY", "test-api-key")
+        .send({
+          profile_name: "CIS Level 1",
+          results,
+        })
+        .expect(200);
+
+      expect(response.body.stats.total_rules).toBe(5);
+      expect(response.body.stats.passed).toBe(2);
+      expect(response.body.stats.failed).toBe(1);
+      expect(response.body.stats.warnings).toBe(1);
+      expect(response.body.stats.skipped).toBe(1);
+    });
+  });
+
+  describe("GET /api/v1/compliance/profiles", () => {
+    it("should return list of profiles", async () => {
+      const mockProfiles = [
+        { id: "1", name: "CIS Level 1", type: "openscap", _count: { compliance_rules: 10, compliance_scans: 5 } },
+        { id: "2", name: "Docker Bench", type: "docker-bench", _count: { compliance_rules: 20, compliance_scans: 3 } },
+      ];
+
+      mockPrisma.compliance_profiles.findMany.mockResolvedValue(mockProfiles);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/profiles")
+        .expect(200);
+
+      expect(response.body).toHaveLength(2);
+      expect(response.body[0].name).toBe("CIS Level 1");
+    });
+  });
+
+  describe("GET /api/v1/compliance/dashboard", () => {
+    it("should return dashboard statistics", async () => {
+      mockPrisma.$queryRaw.mockResolvedValue([
+        { host_id: "1", score: 90 },
+        { host_id: "2", score: 75 },
+        { host_id: "3", score: 50 },
+      ]);
+      mockPrisma.hosts.count.mockResolvedValue(2); // unscanned hosts
+      mockPrisma.compliance_scans.findMany.mockResolvedValue([]);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/dashboard")
+        .expect(200);
+
+      expect(response.body.summary).toBeDefined();
+      expect(response.body.summary.total_hosts).toBe(3);
+      expect(response.body.summary.compliant).toBe(1);
+      expect(response.body.summary.warning).toBe(1);
+      expect(response.body.summary.critical).toBe(1);
+      expect(response.body.summary.unscanned).toBe(2);
+    });
+
+    it("should handle empty database", async () => {
+      mockPrisma.$queryRaw.mockResolvedValue([]);
+      mockPrisma.hosts.count.mockResolvedValue(0);
+      mockPrisma.compliance_scans.findMany.mockResolvedValue([]);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/dashboard")
+        .expect(200);
+
+      expect(response.body.summary.total_hosts).toBe(0);
+      expect(response.body.summary.average_score).toBe(0);
+    });
+  });
+
+  describe("GET /api/v1/compliance/scans/:hostId", () => {
+    it("should return scan history for a host", async () => {
+      const mockScans = [
+        { id: "1", completed_at: new Date(), score: 85 },
+        { id: "2", completed_at: new Date(), score: 80 },
+      ];
+
+      mockPrisma.compliance_scans.findMany.mockResolvedValue(mockScans);
+      mockPrisma.compliance_scans.count.mockResolvedValue(2);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/scans/host-123")
+        .expect(200);
+
+      expect(response.body.scans).toHaveLength(2);
+      expect(response.body.pagination.total).toBe(2);
+    });
+
+    it("should support pagination", async () => {
+      mockPrisma.compliance_scans.findMany.mockResolvedValue([]);
+      mockPrisma.compliance_scans.count.mockResolvedValue(50);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/scans/host-123?limit=10&offset=20")
+        .expect(200);
+
+      expect(response.body.pagination.limit).toBe(10);
+      expect(response.body.pagination.offset).toBe(20);
+      expect(response.body.pagination.total).toBe(50);
+    });
+  });
+
+  describe("GET /api/v1/compliance/scans/:hostId/latest", () => {
+    it("should return the latest scan for a host", async () => {
+      const mockScan = {
+        id: "scan-123",
+        score: 85,
+        compliance_profiles: { name: "CIS Level 1" },
+        compliance_results: [],
+      };
+
+      mockPrisma.compliance_scans.findFirst.mockResolvedValue(mockScan);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/scans/host-123/latest")
+        .expect(200);
+
+      expect(response.body.id).toBe("scan-123");
+      expect(response.body.score).toBe(85);
+    });
+
+    it("should return 404 if no scans found", async () => {
+      mockPrisma.compliance_scans.findFirst.mockResolvedValue(null);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/scans/host-123/latest")
+        .expect(404);
+
+      expect(response.body.error).toBe("No scans found for this host");
+    });
+  });
+
+  describe("GET /api/v1/compliance/results/:scanId", () => {
+    it("should return results for a scan", async () => {
+      const mockResults = [
+        { id: "1", status: "fail", compliance_rules: { title: "Rule 1", severity: "high" } },
+        { id: "2", status: "pass", compliance_rules: { title: "Rule 2", severity: "low" } },
+      ];
+
+      mockPrisma.compliance_results.findMany.mockResolvedValue(mockResults);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/results/scan-123")
+        .expect(200);
+
+      expect(response.body).toHaveLength(2);
+    });
+
+    it("should filter by status", async () => {
+      mockPrisma.compliance_results.findMany.mockResolvedValue([]);
+
+      await request(app)
+        .get("/api/v1/compliance/results/scan-123?status=fail")
+        .expect(200);
+
+      expect(mockPrisma.compliance_results.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { scan_id: "scan-123", status: "fail" },
+        })
+      );
+    });
+  });
+
+  describe("POST /api/v1/compliance/trigger/:hostId", () => {
+    const mockHost = {
+      id: "host-123",
+      api_id: "test-api-id",
+    };
+
+    beforeEach(() => {
+      mockPrisma.hosts.findUnique.mockResolvedValue(mockHost);
+    });
+
+    it("should trigger a compliance scan when host is connected", async () => {
+      const mockWs = {
+        readyState: 1, // WebSocket.OPEN
+        send: jest.fn(),
+      };
+
+      agentWs.isConnected.mockReturnValue(true);
+      agentWs.getConnectionByApiId.mockReturnValue(mockWs);
+
+      const response = await request(app)
+        .post("/api/v1/compliance/trigger/host-123")
+        .send({ profile_type: "openscap" })
+        .expect(200);
+
+      expect(response.body.message).toBe("Compliance scan triggered");
+      expect(mockWs.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: "compliance_scan", profile_type: "openscap" })
+      );
+    });
+
+    it("should return 404 if host not found", async () => {
+      mockPrisma.hosts.findUnique.mockResolvedValue(null);
+
+      const response = await request(app)
+        .post("/api/v1/compliance/trigger/invalid-host")
+        .expect(404);
+
+      expect(response.body.error).toBe("Host not found");
+    });
+
+    it("should return 400 if host is not connected", async () => {
+      agentWs.isConnected.mockReturnValue(false);
+
+      const response = await request(app)
+        .post("/api/v1/compliance/trigger/host-123")
+        .expect(400);
+
+      expect(response.body.error).toBe("Host is not connected");
+    });
+  });
+
+  describe("GET /api/v1/compliance/trends/:hostId", () => {
+    it("should return compliance trends", async () => {
+      const mockScans = [
+        { completed_at: new Date("2024-01-01"), score: 80, compliance_profiles: { name: "CIS", type: "openscap" } },
+        { completed_at: new Date("2024-01-15"), score: 85, compliance_profiles: { name: "CIS", type: "openscap" } },
+        { completed_at: new Date("2024-01-30"), score: 90, compliance_profiles: { name: "CIS", type: "openscap" } },
+      ];
+
+      mockPrisma.compliance_scans.findMany.mockResolvedValue(mockScans);
+
+      const response = await request(app)
+        .get("/api/v1/compliance/trends/host-123")
+        .expect(200);
+
+      expect(response.body).toHaveLength(3);
+    });
+
+    it("should filter by days parameter", async () => {
+      mockPrisma.compliance_scans.findMany.mockResolvedValue([]);
+
+      await request(app)
+        .get("/api/v1/compliance/trends/host-123?days=7")
+        .expect(200);
+
+      expect(mockPrisma.compliance_scans.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            host_id: "host-123",
+            completed_at: expect.any(Object),
+          }),
+        })
+      );
+    });
+  });
+});

--- a/backend/src/routes/complianceRoutes.js
+++ b/backend/src/routes/complianceRoutes.js
@@ -1,0 +1,471 @@
+const express = require("express");
+const router = express.Router();
+const { getPrismaClient } = require("../config/prisma");
+const { authenticateToken } = require("../middleware/auth");
+const { v4: uuidv4 } = require("uuid");
+const bcrypt = require("bcryptjs");
+const crypto = require("node:crypto");
+
+const prisma = getPrismaClient();
+
+/**
+ * Verify API key against stored hash or plaintext (legacy support)
+ */
+async function verifyApiKey(providedKey, storedKey) {
+  if (!providedKey || !storedKey) return false;
+  if (storedKey.match(/^\$2[aby]\$/)) {
+    return bcrypt.compare(providedKey, storedKey);
+  }
+  try {
+    const providedBuffer = Buffer.from(providedKey, "utf8");
+    const storedBuffer = Buffer.from(storedKey, "utf8");
+    if (providedBuffer.length !== storedBuffer.length) return false;
+    return crypto.timingSafeEqual(providedBuffer, storedBuffer);
+  } catch {
+    return false;
+  }
+}
+
+// ==========================================
+// Public endpoints (API key auth for agents)
+// ==========================================
+
+/**
+ * POST /api/v1/compliance/scans
+ * Submit scan results from agent
+ * Auth: X-API-ID and X-API-KEY headers
+ */
+router.post("/scans", async (req, res) => {
+  try {
+    const apiId = req.headers["x-api-id"];
+    const apiKey = req.headers["x-api-key"];
+
+    if (!apiId || !apiKey) {
+      return res.status(401).json({ error: "API credentials required" });
+    }
+
+    // Validate host credentials
+    const host = await prisma.hosts.findFirst({
+      where: { api_id: apiId },
+    });
+
+    if (!host) {
+      return res.status(401).json({ error: "Invalid API credentials" });
+    }
+
+    const isValidKey = await verifyApiKey(apiKey, host.api_key);
+    if (!isValidKey) {
+      return res.status(401).json({ error: "Invalid API credentials" });
+    }
+
+    const { profile_name, profile_type, results, started_at, completed_at, raw_output } = req.body;
+
+    // Find or create profile
+    let profile = await prisma.compliance_profiles.findFirst({
+      where: { name: profile_name },
+    });
+
+    if (!profile) {
+      profile = await prisma.compliance_profiles.create({
+        data: {
+          id: uuidv4(),
+          name: profile_name,
+          type: profile_type || "openscap",
+        },
+      });
+    }
+
+    // Calculate stats
+    const stats = {
+      total_rules: results?.length || 0,
+      passed: results?.filter((r) => r.status === "pass").length || 0,
+      failed: results?.filter((r) => r.status === "fail").length || 0,
+      warnings: results?.filter((r) => r.status === "warn").length || 0,
+      skipped: results?.filter((r) => r.status === "skip").length || 0,
+      not_applicable: results?.filter((r) => r.status === "notapplicable").length || 0,
+    };
+
+    // Calculate score (exclude not_applicable and skipped from denominator)
+    const applicableRules = stats.total_rules - stats.not_applicable - stats.skipped;
+    const score = applicableRules > 0
+      ? ((stats.passed / applicableRules) * 100).toFixed(2)
+      : null;
+
+    // Create scan record
+    const scan = await prisma.compliance_scans.create({
+      data: {
+        id: uuidv4(),
+        host_id: host.id,
+        profile_id: profile.id,
+        started_at: started_at ? new Date(started_at) : new Date(),
+        completed_at: completed_at ? new Date(completed_at) : new Date(),
+        status: "completed",
+        total_rules: stats.total_rules,
+        passed: stats.passed,
+        failed: stats.failed,
+        warnings: stats.warnings,
+        skipped: stats.skipped,
+        score: score ? parseFloat(score) : null,
+        raw_output: raw_output ? JSON.stringify(raw_output) : null,
+      },
+    });
+
+    // Create rule and result records
+    if (results && Array.isArray(results)) {
+      for (const result of results) {
+        // Upsert rule
+        let rule = await prisma.compliance_rules.findFirst({
+          where: {
+            profile_id: profile.id,
+            rule_ref: result.rule_ref || result.id,
+          },
+        });
+
+        if (!rule) {
+          rule = await prisma.compliance_rules.create({
+            data: {
+              id: uuidv4(),
+              profile_id: profile.id,
+              rule_ref: result.rule_ref || result.id,
+              title: result.title || result.rule_ref || "Unknown",
+              description: result.description || null,
+              severity: result.severity || null,
+              section: result.section || null,
+              remediation: result.remediation || null,
+            },
+          });
+        }
+
+        // Create result
+        await prisma.compliance_results.create({
+          data: {
+            id: uuidv4(),
+            scan_id: scan.id,
+            rule_id: rule.id,
+            status: result.status,
+            finding: result.finding || result.message || null,
+            actual: result.actual || null,
+            expected: result.expected || null,
+            remediation: result.remediation || null,
+          },
+        });
+      }
+    }
+
+    console.log(`[Compliance] Scan completed for host ${host.friendly_name || host.hostname}: ${stats.passed}/${stats.total_rules} passed (${score}%)`);
+
+    res.json({
+      message: "Scan results saved successfully",
+      scan_id: scan.id,
+      score: scan.score,
+      stats,
+    });
+  } catch (error) {
+    console.error("[Compliance] Error saving scan results:", error);
+    res.status(500).json({ error: "Failed to save scan results" });
+  }
+});
+
+// ==========================================
+// Protected endpoints (JWT auth for dashboard)
+// ==========================================
+
+// Apply JWT auth to all routes below
+router.use(authenticateToken);
+
+/**
+ * GET /api/v1/compliance/profiles
+ * List all compliance profiles
+ */
+router.get("/profiles", async (req, res) => {
+  try {
+    const profiles = await prisma.compliance_profiles.findMany({
+      orderBy: { name: "asc" },
+      include: {
+        _count: {
+          select: { compliance_rules: true, compliance_scans: true },
+        },
+      },
+    });
+
+    res.json(profiles);
+  } catch (error) {
+    console.error("[Compliance] Error fetching profiles:", error);
+    res.status(500).json({ error: "Failed to fetch profiles" });
+  }
+});
+
+/**
+ * GET /api/v1/compliance/dashboard
+ * Aggregated compliance statistics
+ */
+router.get("/dashboard", async (req, res) => {
+  try {
+    // Get latest scan per host using raw query for PostgreSQL
+    const latestScans = await prisma.$queryRaw`
+      SELECT DISTINCT ON (host_id) *
+      FROM compliance_scans
+      WHERE status = 'completed'
+      ORDER BY host_id, completed_at DESC
+    `;
+
+    // Calculate averages
+    const totalHosts = latestScans.length;
+    const avgScore = totalHosts > 0
+      ? latestScans.reduce((sum, s) => sum + (Number(s.score) || 0), 0) / totalHosts
+      : 0;
+
+    // Get hosts by compliance level
+    const compliant = latestScans.filter((s) => Number(s.score) >= 80).length;
+    const warning = latestScans.filter((s) => Number(s.score) >= 60 && Number(s.score) < 80).length;
+    const critical = latestScans.filter((s) => Number(s.score) < 60).length;
+    const unscanned = await prisma.hosts.count({
+      where: {
+        compliance_scans: { none: {} },
+      },
+    });
+
+    // Recent scans
+    const recentScans = await prisma.compliance_scans.findMany({
+      take: 10,
+      orderBy: { completed_at: "desc" },
+      include: {
+        hosts: { select: { id: true, hostname: true, friendly_name: true } },
+        compliance_profiles: { select: { name: true, type: true } },
+      },
+    });
+
+    // Worst performing hosts (latest scan per host, sorted by score)
+    const worstHostsRaw = await prisma.$queryRaw`
+      SELECT DISTINCT ON (host_id) cs.*, h.hostname, h.friendly_name, cp.name as profile_name
+      FROM compliance_scans cs
+      JOIN hosts h ON cs.host_id = h.id
+      JOIN compliance_profiles cp ON cs.profile_id = cp.id
+      WHERE cs.status = 'completed'
+      ORDER BY cs.host_id, cs.completed_at DESC
+    `;
+
+    // Sort by score ascending and take top 5
+    const worstHosts = worstHostsRaw
+      .sort((a, b) => (Number(a.score) || 0) - (Number(b.score) || 0))
+      .slice(0, 5)
+      .map((h) => ({
+        id: h.id,
+        host_id: h.host_id,
+        score: h.score,
+        completed_at: h.completed_at,
+        host: {
+          id: h.host_id,
+          hostname: h.hostname,
+          friendly_name: h.friendly_name,
+        },
+        profile: {
+          name: h.profile_name,
+        },
+      }));
+
+    res.json({
+      summary: {
+        total_hosts: totalHosts,
+        average_score: Math.round(avgScore * 100) / 100,
+        compliant,
+        warning,
+        critical,
+        unscanned,
+      },
+      recent_scans: recentScans,
+      worst_hosts: worstHosts,
+    });
+  } catch (error) {
+    console.error("[Compliance] Error fetching dashboard:", error);
+    res.status(500).json({ error: "Failed to fetch dashboard data" });
+  }
+});
+
+/**
+ * GET /api/v1/compliance/scans/:hostId
+ * Get scan history for a specific host
+ */
+router.get("/scans/:hostId", async (req, res) => {
+  try {
+    const { hostId } = req.params;
+    const { limit = 20, offset = 0 } = req.query;
+
+    const scans = await prisma.compliance_scans.findMany({
+      where: { host_id: hostId },
+      orderBy: { completed_at: "desc" },
+      take: parseInt(limit),
+      skip: parseInt(offset),
+      include: {
+        compliance_profiles: { select: { name: true, type: true } },
+        _count: { select: { compliance_results: true } },
+      },
+    });
+
+    const total = await prisma.compliance_scans.count({
+      where: { host_id: hostId },
+    });
+
+    res.json({
+      scans,
+      pagination: {
+        total,
+        limit: parseInt(limit),
+        offset: parseInt(offset),
+      },
+    });
+  } catch (error) {
+    console.error("[Compliance] Error fetching scans:", error);
+    res.status(500).json({ error: "Failed to fetch scans" });
+  }
+});
+
+/**
+ * GET /api/v1/compliance/scans/:hostId/latest
+ * Get the latest scan for a host
+ */
+router.get("/scans/:hostId/latest", async (req, res) => {
+  try {
+    const { hostId } = req.params;
+
+    const scan = await prisma.compliance_scans.findFirst({
+      where: { host_id: hostId, status: "completed" },
+      orderBy: { completed_at: "desc" },
+      include: {
+        compliance_profiles: true,
+        compliance_results: {
+          include: {
+            compliance_rules: true,
+          },
+          orderBy: [
+            { status: "asc" }, // fail first
+          ],
+        },
+      },
+    });
+
+    if (!scan) {
+      return res.status(404).json({ error: "No scans found for this host" });
+    }
+
+    res.json(scan);
+  } catch (error) {
+    console.error("[Compliance] Error fetching latest scan:", error);
+    res.status(500).json({ error: "Failed to fetch latest scan" });
+  }
+});
+
+/**
+ * GET /api/v1/compliance/results/:scanId
+ * Get detailed results for a specific scan
+ */
+router.get("/results/:scanId", async (req, res) => {
+  try {
+    const { scanId } = req.params;
+    const { status, severity } = req.query;
+
+    const where = { scan_id: scanId };
+    if (status) where.status = status;
+
+    const results = await prisma.compliance_results.findMany({
+      where,
+      include: {
+        compliance_rules: true,
+      },
+      orderBy: [
+        { status: "asc" },
+      ],
+    });
+
+    // Filter by severity if specified
+    const filteredResults = severity
+      ? results.filter((r) => r.compliance_rules.severity === severity)
+      : results;
+
+    res.json(filteredResults);
+  } catch (error) {
+    console.error("[Compliance] Error fetching results:", error);
+    res.status(500).json({ error: "Failed to fetch results" });
+  }
+});
+
+/**
+ * POST /api/v1/compliance/trigger/:hostId
+ * Trigger an on-demand compliance scan
+ */
+router.post("/trigger/:hostId", async (req, res) => {
+  try {
+    const { hostId } = req.params;
+    const { profile_type = "all" } = req.body; // "openscap", "docker-bench", or "all"
+
+    const host = await prisma.hosts.findUnique({
+      where: { id: hostId },
+    });
+
+    if (!host) {
+      return res.status(404).json({ error: "Host not found" });
+    }
+
+    // Import agentWs to send WebSocket message
+    const agentWs = require("../services/agentWs");
+
+    if (!agentWs.isConnected(host.api_id)) {
+      return res.status(400).json({ error: "Host is not connected" });
+    }
+
+    // Send compliance scan trigger via WebSocket
+    const ws = agentWs.getConnectionByApiId(host.api_id);
+    if (ws && ws.readyState === 1) { // WebSocket.OPEN
+      ws.send(JSON.stringify({
+        type: "compliance_scan",
+        profile_type,
+      }));
+
+      res.json({
+        message: "Compliance scan triggered",
+        host_id: hostId,
+        profile_type,
+      });
+    } else {
+      res.status(400).json({ error: "Failed to send scan trigger" });
+    }
+  } catch (error) {
+    console.error("[Compliance] Error triggering scan:", error);
+    res.status(500).json({ error: "Failed to trigger scan" });
+  }
+});
+
+/**
+ * GET /api/v1/compliance/trends/:hostId
+ * Get compliance score trends over time
+ */
+router.get("/trends/:hostId", async (req, res) => {
+  try {
+    const { hostId } = req.params;
+    const { days = 30 } = req.query;
+
+    const since = new Date();
+    since.setDate(since.getDate() - parseInt(days));
+
+    const scans = await prisma.compliance_scans.findMany({
+      where: {
+        host_id: hostId,
+        status: "completed",
+        completed_at: { gte: since },
+      },
+      orderBy: { completed_at: "asc" },
+      select: {
+        completed_at: true,
+        score: true,
+        compliance_profiles: { select: { name: true, type: true } },
+      },
+    });
+
+    res.json(scans);
+  } catch (error) {
+    console.error("[Compliance] Error fetching trends:", error);
+    res.status(500).json({ error: "Failed to fetch trends" });
+  }
+});
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -94,6 +94,7 @@ const releaseNotesRoutes = require("./routes/releaseNotesRoutes");
 const releaseNotesAcceptanceRoutes = require("./routes/releaseNotesAcceptanceRoutes");
 const buyMeACoffeeRoutes = require("./routes/buyMeACoffeeRoutes");
 const oidcRoutes = require("./routes/oidcRoutes");
+const complianceRoutes = require("./routes/complianceRoutes");
 const { initializeOIDC } = require("./auth/oidc");
 const { initSettings } = require("./services/settingsService");
 const { queueManager } = require("./services/automation");
@@ -556,6 +557,7 @@ app.use(
 	releaseNotesAcceptanceRoutes,
 );
 app.use(`/api/${apiVersion}/buy-me-a-coffee`, buyMeACoffeeRoutes);
+app.use(`/api/${apiVersion}/compliance`, complianceRoutes);
 
 // Bull Board - will be populated after queue manager initializes
 let bullBoardRouter = null;

--- a/backend/src/services/agentWs.js
+++ b/backend/src/services/agentWs.js
@@ -324,6 +324,19 @@ function getConnectionByApiId(apiId) {
 	return apiIdToSocket.get(apiId);
 }
 
+function pushComplianceScan(apiId, profileType = "all") {
+	const ws = apiIdToSocket.get(apiId);
+	if (ws && ws.readyState === WebSocket.OPEN) {
+		safeSend(ws, JSON.stringify({
+			type: "compliance_scan",
+			profile_type: profileType,
+		}));
+		console.log(`[agent-ws] Triggered compliance scan for ${apiId}: ${profileType}`);
+		return true;
+	}
+	return false;
+}
+
 function pushUpdateNotification(apiId, updateInfo) {
 	const ws = apiIdToSocket.get(apiId);
 	if (ws && ws.readyState === WebSocket.OPEN) {
@@ -511,6 +524,7 @@ module.exports = {
 	pushIntegrationToggle,
 	pushUpdateNotification,
 	pushUpdateNotificationToAll,
+	pushComplianceScan,
 	// Expose read-only view of connected agents
 	getConnectedApiIds: () => Array.from(apiIdToSocket.keys()),
 	getConnectionByApiId,


### PR DESCRIPTION
## Summary
- Adds backend API endpoints for receiving and querying compliance scan data
- Implements agent authentication via API key headers (X-API-ID / X-API-KEY)
- Implements dashboard authentication via JWT tokens
- Adds pushComplianceScan function to agentWs service for triggering scans

## Endpoints Added
| Method | Endpoint | Description | Auth |
|--------|----------|-------------|------|
| POST | `/api/v1/compliance/scans` | Submit scan results from agent | API Key |
| GET | `/api/v1/compliance/profiles` | List all compliance profiles | JWT |
| GET | `/api/v1/compliance/dashboard` | Aggregated compliance stats | JWT |
| GET | `/api/v1/compliance/scans/:hostId` | Scan history for a host | JWT |
| GET | `/api/v1/compliance/scans/:hostId/latest` | Latest scan with results | JWT |
| GET | `/api/v1/compliance/results/:scanId` | Detailed results for a scan | JWT |
| POST | `/api/v1/compliance/trigger/:hostId` | Trigger on-demand compliance scan | JWT |
| GET | `/api/v1/compliance/trends/:hostId` | Compliance score trends over time | JWT |

## Test plan
- [x] Unit tests pass for all endpoints
- [x] API credentials validation working
- [x] JWT authentication middleware applied
- [x] WebSocket scan triggering implemented
- [ ] Integration test with actual agent (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)