### PR TITLE
feat(compliance): add frontend dashboard and components

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ const Automation = lazy(() => import("./pages/Automation"));
 const Repositories = lazy(() => import("./pages/Repositories"));
 const RepositoryDetail = lazy(() => import("./pages/RepositoryDetail"));
 const Docker = lazy(() => import("./pages/Docker"));
+const Compliance = lazy(() => import("./pages/Compliance"));
 const DockerContainerDetail = lazy(
 	() => import("./pages/docker/ContainerDetail"),
 );
@@ -154,6 +155,16 @@ function AppRoutes() {
 						<ProtectedRoute requirePermission="can_view_hosts">
 							<Layout>
 								<Automation />
+							</Layout>
+						</ProtectedRoute>
+					}
+				/>
+				<Route
+					path="/compliance"
+					element={
+						<ProtectedRoute requirePermission="can_view_hosts">
+							<Layout>
+								<Compliance />
 							</Layout>
 						</ProtectedRoute>
 					}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -20,6 +20,7 @@ import {
 	Route,
 	Server,
 	Settings,
+	Shield,
 	Star,
 	UserCircle,
 	X,
@@ -153,6 +154,13 @@ const Layout = ({ children }) => {
 				icon: RefreshCw,
 			});
 
+			// Add Compliance item (available to all users with inventory access)
+			inventoryItems.push({
+				name: "Compliance",
+				href: "/compliance",
+				icon: Shield,
+			});
+
 			if (canViewReports()) {
 				inventoryItems.push(
 					{
@@ -243,6 +251,7 @@ const Layout = ({ children }) => {
 		if (path === "/docker") return "Docker";
 		if (path === "/pro-action") return "Pro-Action";
 		if (path === "/automation") return "Automation";
+		if (path === "/compliance") return "Compliance";
 		if (path === "/users") return "Users";
 		if (path === "/permissions") return "Permissions";
 		if (path === "/settings") return "Settings";
@@ -1204,13 +1213,14 @@ const Layout = ({ children }) => {
 					<div className="h-6 w-px bg-secondary-200 dark:bg-secondary-600 lg:hidden" />
 
 					<div className="flex flex-1 gap-x-2 sm:gap-x-4 self-stretch lg:gap-x-6 min-w-0">
-						{/* Page title - hidden on dashboard, hosts, repositories, packages, automation, docker, settings, and host details to give more space to search */}
+						{/* Page title - hidden on dashboard, hosts, repositories, packages, automation, compliance, docker, settings, and host details to give more space to search */}
 						{![
 							"/",
 							"/hosts",
 							"/repositories",
 							"/packages",
 							"/automation",
+							"/compliance",
 							"/docker",
 						].includes(location.pathname) &&
 							!location.pathname.startsWith("/hosts/") &&
@@ -1226,7 +1236,7 @@ const Layout = ({ children }) => {
 
 						{/* Global Search Bar */}
 						<div
-							className={`flex items-center min-w-0 ${["/", "/hosts", "/repositories", "/packages", "/automation", "/docker"].includes(location.pathname) || location.pathname.startsWith("/hosts/") || location.pathname.startsWith("/docker/") || location.pathname.startsWith("/packages/") || location.pathname.startsWith("/settings/") ? "flex-1 max-w-none" : "flex-1 md:flex-none md:max-w-sm"}`}
+							className={`flex items-center min-w-0 ${["/", "/hosts", "/repositories", "/packages", "/automation", "/compliance", "/docker"].includes(location.pathname) || location.pathname.startsWith("/hosts/") || location.pathname.startsWith("/docker/") || location.pathname.startsWith("/packages/") || location.pathname.startsWith("/settings/") ? "flex-1 max-w-none" : "flex-1 md:flex-none md:max-w-sm"}`}
 						>
 							<GlobalSearch />
 						</div>

--- a/frontend/src/components/compliance/ComplianceScore.jsx
+++ b/frontend/src/components/compliance/ComplianceScore.jsx
@@ -1,0 +1,44 @@
+import { ShieldCheck, ShieldAlert, ShieldX, ShieldQuestion } from "lucide-react";
+
+const ComplianceScore = ({ score, size = "md" }) => {
+	const getScoreColor = (score) => {
+		if (score === null || score === undefined) return "text-secondary-400";
+		if (score >= 80) return "text-green-400";
+		if (score >= 60) return "text-yellow-400";
+		return "text-red-400";
+	};
+
+	const getScoreBg = (score) => {
+		if (score === null || score === undefined) return "bg-secondary-700";
+		if (score >= 80) return "bg-green-900/30";
+		if (score >= 60) return "bg-yellow-900/30";
+		return "bg-red-900/30";
+	};
+
+	const getIcon = (score) => {
+		if (score === null || score === undefined) return ShieldQuestion;
+		if (score >= 80) return ShieldCheck;
+		if (score >= 60) return ShieldAlert;
+		return ShieldX;
+	};
+
+	const Icon = getIcon(score);
+	const sizeClasses = {
+		sm: "text-sm px-2 py-1",
+		md: "text-base px-3 py-1.5",
+		lg: "text-lg px-4 py-2",
+	};
+
+	return (
+		<div
+			className={`inline-flex items-center gap-1.5 rounded-full ${getScoreBg(score)} ${sizeClasses[size]}`}
+		>
+			<Icon className={`h-4 w-4 ${getScoreColor(score)}`} />
+			<span className={`font-semibold ${getScoreColor(score)}`}>
+				{score !== null && score !== undefined ? `${score.toFixed(0)}%` : "N/A"}
+			</span>
+		</div>
+	);
+};
+
+export default ComplianceScore;

--- a/frontend/src/components/compliance/ComplianceTab.jsx
+++ b/frontend/src/components/compliance/ComplianceTab.jsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+	Shield,
+	Play,
+	RefreshCw,
+	CheckCircle,
+	XCircle,
+	AlertTriangle,
+	MinusCircle,
+	ChevronDown,
+	ChevronRight,
+} from "lucide-react";
+import { complianceAPI } from "../../utils/complianceApi";
+import ComplianceScore from "./ComplianceScore";
+
+const ComplianceTab = ({ hostId, isConnected }) => {
+	const [expandedRules, setExpandedRules] = useState({});
+	const [statusFilter, setStatusFilter] = useState("all");
+	const queryClient = useQueryClient();
+
+	const { data: latestScan, isLoading } = useQuery({
+		queryKey: ["compliance-latest", hostId],
+		queryFn: () => complianceAPI.getLatestScan(hostId).then((res) => res.data),
+		enabled: !!hostId,
+	});
+
+	const { data: scanHistory } = useQuery({
+		queryKey: ["compliance-history", hostId],
+		queryFn: () => complianceAPI.getHostScans(hostId, { limit: 5 }).then((res) => res.data),
+		enabled: !!hostId,
+	});
+
+	const triggerScan = useMutation({
+		mutationFn: (profileType) => complianceAPI.triggerScan(hostId, profileType),
+		onSuccess: () => {
+			queryClient.invalidateQueries(["compliance-latest", hostId]);
+			queryClient.invalidateQueries(["compliance-history", hostId]);
+		},
+	});
+
+	const toggleRule = (ruleId) => {
+		setExpandedRules((prev) => ({
+			...prev,
+			[ruleId]: !prev[ruleId],
+		}));
+	};
+
+	const getStatusIcon = (status) => {
+		switch (status) {
+			case "pass":
+				return <CheckCircle className="h-4 w-4 text-green-400" />;
+			case "fail":
+				return <XCircle className="h-4 w-4 text-red-400" />;
+			case "warn":
+				return <AlertTriangle className="h-4 w-4 text-yellow-400" />;
+			default:
+				return <MinusCircle className="h-4 w-4 text-secondary-400" />;
+		}
+	};
+
+	const filteredResults = latestScan?.results?.filter((r) =>
+		statusFilter === "all" ? true : r.status === statusFilter
+	);
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center h-64">
+				<div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500"></div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-6">
+			{/* Header with Scan Button */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-3">
+					<Shield className="h-6 w-6 text-primary-400" />
+					<h2 className="text-xl font-semibold text-white">Security Compliance</h2>
+				</div>
+				<button
+					onClick={() => triggerScan.mutate("all")}
+					disabled={!isConnected || triggerScan.isPending}
+					className="flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 disabled:bg-secondary-700 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+				>
+					{triggerScan.isPending ? (
+						<RefreshCw className="h-4 w-4 animate-spin" />
+					) : (
+						<Play className="h-4 w-4" />
+					)}
+					Run Scan
+				</button>
+			</div>
+
+			{/* Latest Scan Summary */}
+			{latestScan ? (
+				<div className="bg-secondary-800 rounded-lg border border-secondary-700 p-4">
+					<div className="flex items-center justify-between mb-4">
+						<div>
+							<p className="text-sm text-secondary-400">Latest Scan</p>
+							<p className="text-white font-medium">{latestScan.profile?.name}</p>
+							<p className="text-xs text-secondary-500">
+								{new Date(latestScan.completed_at).toLocaleString()}
+							</p>
+						</div>
+						<ComplianceScore score={latestScan.score} size="lg" />
+					</div>
+
+					{/* Stats */}
+					<div className="grid grid-cols-5 gap-2 text-center">
+						<div className="bg-secondary-700/50 rounded p-2">
+							<p className="text-lg font-bold text-white">{latestScan.total_rules}</p>
+							<p className="text-xs text-secondary-400">Total</p>
+						</div>
+						<div className="bg-green-900/20 rounded p-2">
+							<p className="text-lg font-bold text-green-400">{latestScan.passed}</p>
+							<p className="text-xs text-secondary-400">Passed</p>
+						</div>
+						<div className="bg-red-900/20 rounded p-2">
+							<p className="text-lg font-bold text-red-400">{latestScan.failed}</p>
+							<p className="text-xs text-secondary-400">Failed</p>
+						</div>
+						<div className="bg-yellow-900/20 rounded p-2">
+							<p className="text-lg font-bold text-yellow-400">{latestScan.warnings}</p>
+							<p className="text-xs text-secondary-400">Warnings</p>
+						</div>
+						<div className="bg-secondary-700/50 rounded p-2">
+							<p className="text-lg font-bold text-secondary-400">{latestScan.skipped + latestScan.not_applicable}</p>
+							<p className="text-xs text-secondary-400">Skipped</p>
+						</div>
+					</div>
+				</div>
+			) : (
+				<div className="bg-secondary-800 rounded-lg border border-secondary-700 p-8 text-center">
+					<Shield className="h-12 w-12 text-secondary-600 mx-auto mb-3" />
+					<p className="text-secondary-400">No compliance scans yet</p>
+					<p className="text-sm text-secondary-500 mt-1">
+						Run a scan to check this host against CIS benchmarks
+					</p>
+				</div>
+			)}
+
+			{/* Results Filter */}
+			{latestScan?.results && (
+				<div className="flex gap-2">
+					{["all", "fail", "warn", "pass"].map((status) => (
+						<button
+							key={status}
+							onClick={() => setStatusFilter(status)}
+							className={`px-3 py-1 rounded-full text-sm capitalize transition-colors ${
+								statusFilter === status
+									? "bg-primary-600 text-white"
+									: "bg-secondary-700 text-secondary-300 hover:bg-secondary-600"
+							}`}
+						>
+							{status}
+						</button>
+					))}
+				</div>
+			)}
+
+			{/* Results List */}
+			{filteredResults && filteredResults.length > 0 && (
+				<div className="bg-secondary-800 rounded-lg border border-secondary-700 divide-y divide-secondary-700">
+					{filteredResults.map((result) => (
+						<div key={result.id} className="p-3">
+							<button
+								onClick={() => toggleRule(result.id)}
+								className="w-full flex items-center gap-3 text-left"
+							>
+								{expandedRules[result.id] ? (
+									<ChevronDown className="h-4 w-4 text-secondary-400 flex-shrink-0" />
+								) : (
+									<ChevronRight className="h-4 w-4 text-secondary-400 flex-shrink-0" />
+								)}
+								{getStatusIcon(result.status)}
+								<div className="flex-1 min-w-0">
+									<p className="text-white font-medium truncate">{result.rule?.title}</p>
+									<p className="text-xs text-secondary-400">
+										{result.rule?.section && `${result.rule.section} • `}
+										{result.rule?.severity && (
+											<span className={`capitalize ${
+												result.rule.severity === "critical" ? "text-red-400" :
+												result.rule.severity === "high" ? "text-orange-400" :
+												result.rule.severity === "medium" ? "text-yellow-400" :
+												"text-secondary-400"
+											}`}>
+												{result.rule.severity}
+											</span>
+										)}
+									</p>
+								</div>
+							</button>
+
+							{expandedRules[result.id] && (
+								<div className="mt-3 ml-7 space-y-2 text-sm">
+									{result.rule?.description && (
+										<div>
+											<p className="text-secondary-400 font-medium">Description</p>
+											<p className="text-secondary-300">{result.rule.description}</p>
+										</div>
+									)}
+									{result.finding && (
+										<div>
+											<p className="text-secondary-400 font-medium">Finding</p>
+											<p className="text-secondary-300">{result.finding}</p>
+										</div>
+									)}
+									{result.rule?.remediation && (
+										<div>
+											<p className="text-secondary-400 font-medium">Remediation</p>
+											<p className="text-secondary-300">{result.rule.remediation}</p>
+										</div>
+									)}
+								</div>
+							)}
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default ComplianceTab;

--- a/frontend/src/components/compliance/ComplianceTrend.jsx
+++ b/frontend/src/components/compliance/ComplianceTrend.jsx
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { complianceAPI } from "../../utils/complianceApi";
+
+const ComplianceTrend = ({ hostId, days = 30 }) => {
+	const { data: trends } = useQuery({
+		queryKey: ["compliance-trends", hostId, days],
+		queryFn: () => complianceAPI.getTrends(hostId, days).then((res) => res.data),
+		enabled: !!hostId,
+	});
+
+	if (!trends || trends.length === 0) {
+		return null;
+	}
+
+	const chartData = trends.map((t) => ({
+		date: new Date(t.completed_at).toLocaleDateString(),
+		score: t.score,
+	}));
+
+	return (
+		<div className="bg-secondary-800 rounded-lg border border-secondary-700 p-4">
+			<h3 className="text-white font-medium mb-4">Compliance Trend</h3>
+			<div className="h-48">
+				<ResponsiveContainer width="100%" height="100%">
+					<LineChart data={chartData}>
+						<XAxis
+							dataKey="date"
+							stroke="#6b7280"
+							fontSize={12}
+							tickLine={false}
+						/>
+						<YAxis
+							domain={[0, 100]}
+							stroke="#6b7280"
+							fontSize={12}
+							tickLine={false}
+							tickFormatter={(v) => `${v}%`}
+						/>
+						<Tooltip
+							contentStyle={{
+								backgroundColor: "#1f2937",
+								border: "1px solid #374151",
+								borderRadius: "0.5rem",
+							}}
+							labelStyle={{ color: "#9ca3af" }}
+							formatter={(value) => [`${value.toFixed(1)}%`, "Score"]}
+						/>
+						<Line
+							type="monotone"
+							dataKey="score"
+							stroke="#3b82f6"
+							strokeWidth={2}
+							dot={{ fill: "#3b82f6", r: 4 }}
+						/>
+					</LineChart>
+				</ResponsiveContainer>
+			</div>
+		</div>
+	);
+};
+
+export default ComplianceTrend;

--- a/frontend/src/pages/Compliance.jsx
+++ b/frontend/src/pages/Compliance.jsx
@@ -1,0 +1,168 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import {
+	Shield,
+	ShieldCheck,
+	ShieldAlert,
+	ShieldX,
+	TrendingUp,
+	TrendingDown,
+	Clock,
+	Server,
+} from "lucide-react";
+import { complianceAPI } from "../utils/complianceApi";
+import ComplianceScore from "../components/compliance/ComplianceScore";
+
+const Compliance = () => {
+	const { data: dashboard, isLoading, error } = useQuery({
+		queryKey: ["compliance-dashboard"],
+		queryFn: () => complianceAPI.getDashboard().then((res) => res.data),
+		refetchInterval: 30000,
+	});
+
+	if (isLoading) {
+		return (
+			<div className="flex items-center justify-center h-64">
+				<div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500"></div>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="p-4 bg-red-900/50 border border-red-700 rounded-lg">
+				<p className="text-red-200">Failed to load compliance dashboard</p>
+			</div>
+		);
+	}
+
+	const { summary, recent_scans, worst_hosts } = dashboard || {};
+
+	return (
+		<div className="space-y-6">
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-3">
+					<Shield className="h-8 w-8 text-primary-400" />
+					<h1 className="text-2xl font-bold text-white">Security Compliance</h1>
+				</div>
+			</div>
+
+			{/* Summary Cards */}
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+				<div className="bg-secondary-800 rounded-lg p-4 border border-secondary-700">
+					<div className="flex items-center gap-2 text-secondary-400 mb-2">
+						<Server className="h-4 w-4" />
+						<span className="text-sm">Total Hosts</span>
+					</div>
+					<p className="text-2xl font-bold text-white">{summary?.total_hosts || 0}</p>
+				</div>
+
+				<div className="bg-secondary-800 rounded-lg p-4 border border-secondary-700">
+					<div className="flex items-center gap-2 text-secondary-400 mb-2">
+						<TrendingUp className="h-4 w-4" />
+						<span className="text-sm">Average Score</span>
+					</div>
+					<p className="text-2xl font-bold text-white">{summary?.average_score?.toFixed(1) || 0}%</p>
+				</div>
+
+				<div className="bg-secondary-800 rounded-lg p-4 border border-green-700/50">
+					<div className="flex items-center gap-2 text-green-400 mb-2">
+						<ShieldCheck className="h-4 w-4" />
+						<span className="text-sm">Compliant</span>
+					</div>
+					<p className="text-2xl font-bold text-green-400">{summary?.compliant || 0}</p>
+				</div>
+
+				<div className="bg-secondary-800 rounded-lg p-4 border border-yellow-700/50">
+					<div className="flex items-center gap-2 text-yellow-400 mb-2">
+						<ShieldAlert className="h-4 w-4" />
+						<span className="text-sm">Warning</span>
+					</div>
+					<p className="text-2xl font-bold text-yellow-400">{summary?.warning || 0}</p>
+				</div>
+
+				<div className="bg-secondary-800 rounded-lg p-4 border border-red-700/50">
+					<div className="flex items-center gap-2 text-red-400 mb-2">
+						<ShieldX className="h-4 w-4" />
+						<span className="text-sm">Critical</span>
+					</div>
+					<p className="text-2xl font-bold text-red-400">{summary?.critical || 0}</p>
+				</div>
+			</div>
+
+			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+				{/* Recent Scans */}
+				<div className="bg-secondary-800 rounded-lg border border-secondary-700">
+					<div className="px-4 py-3 border-b border-secondary-700">
+						<h2 className="text-lg font-semibold text-white flex items-center gap-2">
+							<Clock className="h-5 w-5 text-secondary-400" />
+							Recent Scans
+						</h2>
+					</div>
+					<div className="divide-y divide-secondary-700">
+						{recent_scans?.map((scan) => (
+							<Link
+								key={scan.id}
+								to={`/hosts/${scan.host?.id}`}
+								className="flex items-center justify-between px-4 py-3 hover:bg-secondary-700/50 transition-colors"
+							>
+								<div>
+									<p className="text-white font-medium">
+										{scan.host?.friendly_name || scan.host?.hostname}
+									</p>
+									<p className="text-sm text-secondary-400">{scan.profile?.name}</p>
+								</div>
+								<div className="flex items-center gap-3">
+									<ComplianceScore score={scan.score} size="sm" />
+									<span className="text-xs text-secondary-500">
+										{new Date(scan.completed_at).toLocaleDateString()}
+									</span>
+								</div>
+							</Link>
+						))}
+						{(!recent_scans || recent_scans.length === 0) && (
+							<div className="px-4 py-8 text-center text-secondary-400">
+								No compliance scans yet
+							</div>
+						)}
+					</div>
+				</div>
+
+				{/* Worst Performing Hosts */}
+				<div className="bg-secondary-800 rounded-lg border border-secondary-700">
+					<div className="px-4 py-3 border-b border-secondary-700">
+						<h2 className="text-lg font-semibold text-white flex items-center gap-2">
+							<TrendingDown className="h-5 w-5 text-red-400" />
+							Needs Attention
+						</h2>
+					</div>
+					<div className="divide-y divide-secondary-700">
+						{worst_hosts?.map((scan) => (
+							<Link
+								key={scan.id}
+								to={`/hosts/${scan.host?.id}`}
+								className="flex items-center justify-between px-4 py-3 hover:bg-secondary-700/50 transition-colors"
+							>
+								<div>
+									<p className="text-white font-medium">
+										{scan.host?.friendly_name || scan.host?.hostname}
+									</p>
+									<p className="text-sm text-secondary-400">{scan.profile?.name}</p>
+								</div>
+								<ComplianceScore score={scan.score} size="sm" />
+							</Link>
+						))}
+						{(!worst_hosts || worst_hosts.length === 0) && (
+							<div className="px-4 py-8 text-center text-secondary-400">
+								No hosts with low compliance scores
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Compliance;

--- a/frontend/src/pages/HostDetail.jsx
+++ b/frontend/src/pages/HostDetail.jsx
@@ -31,6 +31,7 @@ import {
 } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import ComplianceTab from "../components/compliance/ComplianceTab";
 import InlineEdit from "../components/InlineEdit";
 import InlineMultiGroupEdit from "../components/InlineMultiGroupEdit";
 import SshTerminal from "../components/SshTerminal";
@@ -1626,6 +1627,18 @@ const HostDetail = () => {
 						</button>
 						<button
 							type="button"
+							onClick={() => handleTabChange("compliance")}
+							className={`px-4 py-2 text-sm font-medium ${
+								activeTab === "compliance"
+									? "text-primary-600 dark:text-primary-400 border-b-2 border-primary-500"
+									: "text-secondary-500 dark:text-secondary-400 hover:text-secondary-700 dark:hover:text-secondary-300"
+							}`}
+						>
+							<Shield className="h-4 w-4 inline mr-1" />
+							Compliance
+						</button>
+						<button
+							type="button"
 							onClick={() => handleTabChange("terminal")}
 							className={`px-4 py-2 text-sm font-medium ${
 								activeTab === "terminal"
@@ -2718,6 +2731,11 @@ const HostDetail = () => {
 									</div>
 								)}
 							</div>
+						)}
+
+						{/* Compliance */}
+						{activeTab === "compliance" && (
+							<ComplianceTab hostId={hostId} isConnected={wsStatus?.connected} />
 						)}
 					</div>
 				</div>

--- a/frontend/src/utils/complianceApi.js
+++ b/frontend/src/utils/complianceApi.js
@@ -1,0 +1,29 @@
+import api from "./api";
+
+export const complianceAPI = {
+	// Get all compliance profiles
+	getProfiles: () => api.get("/compliance/profiles"),
+
+	// Get dashboard statistics
+	getDashboard: () => api.get("/compliance/dashboard"),
+
+	// Get scan history for a host
+	getHostScans: (hostId, params = {}) =>
+		api.get(`/compliance/scans/${hostId}`, { params }),
+
+	// Get latest scan for a host
+	getLatestScan: (hostId) =>
+		api.get(`/compliance/scans/${hostId}/latest`),
+
+	// Get detailed results for a scan
+	getScanResults: (scanId, params = {}) =>
+		api.get(`/compliance/results/${scanId}`, { params }),
+
+	// Trigger a compliance scan
+	triggerScan: (hostId, profileType = "all") =>
+		api.post(`/compliance/trigger/${hostId}`, { profile_type: profileType }),
+
+	// Get compliance score trends
+	getTrends: (hostId, days = 30) =>
+		api.get(`/compliance/trends/${hostId}`, { params: { days } }),
+};


### PR DESCRIPTION
## Summary
- Add Compliance dashboard page with overview statistics showing total hosts, average score, and compliance status breakdown
- Add ComplianceScore component for visual score display with color-coded indicators
- Add ComplianceTab for host detail page allowing users to view scan results and trigger new scans
- Add ComplianceTrend chart component for visualizing score trends over time
- Add compliance API utilities for data fetching
- Add sidebar navigation link and route configuration

## Test plan
- [ ] Navigate to the Compliance page from the sidebar
- [ ] Verify dashboard displays summary statistics
- [ ] Navigate to a host detail page and click the Compliance tab
- [ ] Verify the Run Scan button is displayed
- [ ] Verify scan results are displayed with expandable details

🤖 Generated with [Claude Code](https://claude.com/claude-code)