### PR TITLE
test(compliance): add integration tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ PatchMon provides centralized patch management across diverse server environment
 - Rate limiting for general, auth, and agent endpoints
 - Outbound‑only agent model reduces attack surface
 
+### Security Compliance
+- **OpenSCAP** - CIS Benchmarks for Linux hosts (Ubuntu, Debian, RHEL, CentOS, Rocky)
+- **Docker Bench for Security** - CIS Docker Benchmark for container security
+- Automated scheduled scans (configurable interval)
+- On-demand scan triggering from dashboard
+- Compliance score tracking over time
+- Detailed rule-level results with remediation guidance
+- Dashboard with fleet-wide compliance overview
+
+See [Security Compliance Installation Guide](docs/security-compliance/INSTALLATION.md) for setup instructions.
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `COMPLIANCE_SCAN_INTERVAL` | `86400` | Seconds between scheduled scans |
+| `COMPLIANCE_ENABLED` | `true` | Enable/disable compliance feature |
+
 ### Deployment & Operations
 - Docker installation & One‑line self‑host installer (Ubuntu/Debian)
 - systemd service for backend lifecycle

--- a/docs/security-compliance/API-REFERENCE.md
+++ b/docs/security-compliance/API-REFERENCE.md
@@ -1,0 +1,262 @@
+# Security Compliance API Reference
+
+## Authentication
+
+### Agent Endpoints
+Agent endpoints use API key authentication via headers:
+- `X-API-ID`: Host API ID
+- `X-API-KEY`: Host API Key
+
+### Dashboard Endpoints
+Dashboard endpoints require JWT authentication:
+- `Authorization: Bearer <token>`
+
+---
+
+## Endpoints
+
+### Submit Scan Results
+**POST** `/api/v1/compliance/scans`
+
+Submit compliance scan results from an agent.
+
+**Authentication:** API Key
+
+**Request Body:**
+```json
+{
+  "profile_name": "CIS Docker Benchmark",
+  "profile_type": "docker-bench",
+  "started_at": "2024-01-15T10:00:00Z",
+  "completed_at": "2024-01-15T10:05:00Z",
+  "results": [
+    {
+      "rule_ref": "1.1.1",
+      "title": "Ensure a separate partition for containers has been created",
+      "status": "pass",
+      "severity": "high",
+      "section": "1",
+      "finding": "Check passed",
+      "actual": "/var/lib/docker on separate partition",
+      "expected": "Separate partition for /var/lib/docker"
+    }
+  ],
+  "raw_output": "..."
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Scan results saved successfully",
+  "scan_id": "uuid",
+  "score": 85.5,
+  "stats": {
+    "total_rules": 100,
+    "passed": 85,
+    "failed": 10,
+    "warnings": 3,
+    "skipped": 2,
+    "not_applicable": 0
+  }
+}
+```
+
+---
+
+### Get Dashboard Statistics
+**GET** `/api/v1/compliance/dashboard`
+
+Get aggregated compliance statistics for all hosts.
+
+**Authentication:** JWT
+
+**Response:**
+```json
+{
+  "summary": {
+    "total_hosts": 50,
+    "average_score": 78.5,
+    "compliant": 35,
+    "warning": 10,
+    "critical": 3,
+    "unscanned": 2
+  },
+  "recent_scans": [...],
+  "worst_hosts": [...]
+}
+```
+
+---
+
+### List Profiles
+**GET** `/api/v1/compliance/profiles`
+
+List all available compliance profiles.
+
+**Authentication:** JWT
+
+**Response:**
+```json
+[
+  {
+    "id": "uuid",
+    "name": "CIS Ubuntu 22.04 Level 1",
+    "type": "openscap",
+    "os_family": "ubuntu",
+    "_count": {
+      "rules": 250,
+      "scans": 100
+    }
+  }
+]
+```
+
+---
+
+### Get Scan History
+**GET** `/api/v1/compliance/scans/:hostId`
+
+Get scan history for a specific host.
+
+**Authentication:** JWT
+
+**Query Parameters:**
+- `limit` (default: 20) - Number of results
+- `offset` (default: 0) - Pagination offset
+
+**Response:**
+```json
+{
+  "scans": [...],
+  "pagination": {
+    "total": 50,
+    "limit": 20,
+    "offset": 0
+  }
+}
+```
+
+---
+
+### Get Latest Scan
+**GET** `/api/v1/compliance/scans/:hostId/latest`
+
+Get the most recent completed scan for a host.
+
+**Authentication:** JWT
+
+**Response:** Full scan object with results
+
+**Error Response (404):**
+```json
+{
+  "error": "No scans found for this host"
+}
+```
+
+---
+
+### Get Scan Results
+**GET** `/api/v1/compliance/results/:scanId`
+
+Get detailed results for a specific scan.
+
+**Authentication:** JWT
+
+**Query Parameters:**
+- `status` - Filter by status (pass, fail, warn, skip)
+- `severity` - Filter by severity (low, medium, high, critical)
+
+**Response:**
+```json
+[
+  {
+    "id": "uuid",
+    "status": "fail",
+    "compliance_rules": {
+      "title": "Ensure /tmp is a separate partition",
+      "severity": "high",
+      "rule_ref": "1.1.1"
+    }
+  }
+]
+```
+
+---
+
+### Trigger Scan
+**POST** `/api/v1/compliance/trigger/:hostId`
+
+Trigger an on-demand compliance scan via WebSocket.
+
+**Authentication:** JWT
+
+**Request Body:**
+```json
+{
+  "profile_type": "all"
+}
+```
+
+Profile type options: `"openscap"`, `"docker-bench"`, or `"all"`
+
+**Response:**
+```json
+{
+  "message": "Compliance scan triggered",
+  "host_id": "uuid",
+  "profile_type": "all"
+}
+```
+
+**Error Responses:**
+
+| Status | Error | Description |
+|--------|-------|-------------|
+| 400 | Host is not connected | Agent WebSocket not connected |
+| 404 | Host not found | Host doesn't exist |
+
+---
+
+### Get Score Trends
+**GET** `/api/v1/compliance/trends/:hostId`
+
+Get compliance score trends over time.
+
+**Authentication:** JWT
+
+**Query Parameters:**
+- `days` (default: 30) - Number of days of history
+
+**Response:**
+```json
+[
+  {
+    "completed_at": "2024-01-15T10:00:00Z",
+    "score": 85.0,
+    "profile": {
+      "name": "CIS Docker",
+      "type": "docker-bench"
+    }
+  }
+]
+```
+
+---
+
+## Status Codes
+
+| Code | Description |
+|------|-------------|
+| 200 | Success |
+| 400 | Bad Request |
+| 401 | Unauthorized |
+| 404 | Not Found |
+| 500 | Internal Server Error |
+
+## Rate Limiting
+
+- Agent scan submissions: 1 per minute per host
+- Dashboard endpoints: Standard API rate limits
+- Trigger endpoint: 1 per 5 minutes per host

--- a/frontend/src/__tests__/components/Compliance.test.jsx
+++ b/frontend/src/__tests__/components/Compliance.test.jsx
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for Compliance Dashboard Page
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter } from "react-router-dom";
+import Compliance from "../../pages/Compliance";
+
+// Mock the complianceAPI
+vi.mock("../../utils/complianceApi", () => ({
+	complianceAPI: {
+		getDashboard: vi.fn(),
+	},
+}));
+
+import { complianceAPI } from "../../utils/complianceApi";
+
+describe("Compliance Dashboard", () => {
+	let queryClient;
+
+	const mockDashboardData = {
+		summary: {
+			total_hosts: 10,
+			average_score: 78.5,
+			compliant: 6,
+			warning: 2,
+			critical: 1,
+			unscanned: 1,
+		},
+		recent_scans: [
+			{
+				id: "scan-1",
+				host: { id: "host-1", friendly_name: "web-server-01", hostname: "web-server-01.local" },
+				profile: { name: "CIS Ubuntu 22.04 L1" },
+				score: 85,
+				completed_at: "2024-01-15T10:00:00Z",
+			},
+			{
+				id: "scan-2",
+				host: { id: "host-2", friendly_name: "db-server-01", hostname: "db-server-01.local" },
+				profile: { name: "CIS Docker" },
+				score: 72,
+				completed_at: "2024-01-14T10:00:00Z",
+			},
+		],
+		worst_hosts: [
+			{
+				id: "scan-3",
+				host: { id: "host-3", friendly_name: "legacy-server", hostname: "legacy.local" },
+				profile: { name: "CIS Ubuntu 20.04 L1" },
+				score: 45,
+			},
+		],
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+			},
+		});
+	});
+
+	const renderComponent = () => {
+		return render(
+			<QueryClientProvider client={queryClient}>
+				<BrowserRouter>
+					<Compliance />
+				</BrowserRouter>
+			</QueryClientProvider>,
+		);
+	};
+
+	describe("Loading State", () => {
+		it("should display loading spinner while fetching data", () => {
+			complianceAPI.getDashboard.mockImplementation(
+				() => new Promise(() => {}), // Never resolves
+			);
+
+			const { container } = renderComponent();
+
+			// Should show loading spinner
+			const spinner = container.querySelector(".animate-spin");
+			expect(spinner).toBeInTheDocument();
+		});
+	});
+
+	describe("Success State", () => {
+		it("should render the compliance dashboard header", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText(/Security Compliance/i)).toBeInTheDocument();
+			});
+		});
+
+		it("should display total hosts count", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText("10")).toBeInTheDocument();
+			});
+		});
+
+		it("should display average compliance score", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText(/78\.5%/)).toBeInTheDocument();
+			});
+		});
+
+		it("should display compliant hosts count", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText("6")).toBeInTheDocument();
+			});
+		});
+
+		it("should display warning hosts count", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText("2")).toBeInTheDocument();
+			});
+		});
+
+		it("should display critical hosts count", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText("1")).toBeInTheDocument();
+			});
+		});
+
+		it("should display recent scans section", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText(/Recent Scans/i)).toBeInTheDocument();
+			});
+		});
+
+		it("should display recent scan entries", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText("web-server-01")).toBeInTheDocument();
+				expect(screen.getByText("db-server-01")).toBeInTheDocument();
+			});
+		});
+
+		it("should display profile names in recent scans", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText("CIS Ubuntu 22.04 L1")).toBeInTheDocument();
+				expect(screen.getByText("CIS Docker")).toBeInTheDocument();
+			});
+		});
+
+		it("should display needs attention section", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText(/Needs Attention/i)).toBeInTheDocument();
+			});
+		});
+
+		it("should display worst performing hosts", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText("legacy-server")).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("Empty State", () => {
+		it("should display empty state when no recent scans", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({
+				data: {
+					summary: {
+						total_hosts: 0,
+						average_score: 0,
+						compliant: 0,
+						warning: 0,
+						critical: 0,
+						unscanned: 0,
+					},
+					recent_scans: [],
+					worst_hosts: [],
+				},
+			});
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText(/No compliance scans yet/i)).toBeInTheDocument();
+			});
+		});
+
+		it("should display empty state when no worst hosts", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({
+				data: {
+					summary: mockDashboardData.summary,
+					recent_scans: mockDashboardData.recent_scans,
+					worst_hosts: [],
+				},
+			});
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText(/No hosts with low compliance scores/i)).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("Error State", () => {
+		it("should display error message when API call fails", async () => {
+			complianceAPI.getDashboard.mockRejectedValue(new Error("Failed to fetch"));
+
+			renderComponent();
+
+			await waitFor(() => {
+				expect(screen.getByText(/Failed to load compliance dashboard/i)).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("Navigation", () => {
+		it("should have links to host details in recent scans", async () => {
+			complianceAPI.getDashboard.mockResolvedValue({ data: mockDashboardData });
+
+			renderComponent();
+
+			await waitFor(() => {
+				const links = screen.getAllByRole("link");
+				const hostLinks = links.filter((link) => link.getAttribute("href")?.includes("/hosts/"));
+				expect(hostLinks.length).toBeGreaterThan(0);
+			});
+		});
+	});
+});

--- a/frontend/src/__tests__/components/ComplianceScore.test.jsx
+++ b/frontend/src/__tests__/components/ComplianceScore.test.jsx
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for ComplianceScore Component
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ComplianceScore from "../../components/compliance/ComplianceScore";
+
+describe("ComplianceScore Component", () => {
+	describe("Score Display", () => {
+		it("should display score as percentage", () => {
+			render(<ComplianceScore score={85} />);
+			expect(screen.getByText("85%")).toBeInTheDocument();
+		});
+
+		it("should round score to whole number", () => {
+			render(<ComplianceScore score={85.7} />);
+			expect(screen.getByText("86%")).toBeInTheDocument();
+		});
+
+		it("should display N/A when score is null", () => {
+			render(<ComplianceScore score={null} />);
+			expect(screen.getByText("N/A")).toBeInTheDocument();
+		});
+
+		it("should display N/A when score is undefined", () => {
+			render(<ComplianceScore score={undefined} />);
+			expect(screen.getByText("N/A")).toBeInTheDocument();
+		});
+
+		it("should display 0% for zero score", () => {
+			render(<ComplianceScore score={0} />);
+			expect(screen.getByText("0%")).toBeInTheDocument();
+		});
+
+		it("should display 100% for perfect score", () => {
+			render(<ComplianceScore score={100} />);
+			expect(screen.getByText("100%")).toBeInTheDocument();
+		});
+	});
+
+	describe("Color Coding - High Score (Compliant)", () => {
+		it("should apply green color for score >= 80", () => {
+			const { container } = render(<ComplianceScore score={80} />);
+			const scoreElement = screen.getByText("80%");
+			expect(scoreElement.className).toContain("text-green-400");
+		});
+
+		it("should apply green color for score of 90", () => {
+			const { container } = render(<ComplianceScore score={90} />);
+			const scoreElement = screen.getByText("90%");
+			expect(scoreElement.className).toContain("text-green-400");
+		});
+
+		it("should apply green color for score of 100", () => {
+			render(<ComplianceScore score={100} />);
+			const scoreElement = screen.getByText("100%");
+			expect(scoreElement.className).toContain("text-green-400");
+		});
+
+		it("should apply green background for high scores", () => {
+			const { container } = render(<ComplianceScore score={85} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("bg-green-900/30");
+		});
+	});
+
+	describe("Color Coding - Medium Score (Warning)", () => {
+		it("should apply yellow color for score >= 60 and < 80", () => {
+			render(<ComplianceScore score={70} />);
+			const scoreElement = screen.getByText("70%");
+			expect(scoreElement.className).toContain("text-yellow-400");
+		});
+
+		it("should apply yellow color for score of 60", () => {
+			render(<ComplianceScore score={60} />);
+			const scoreElement = screen.getByText("60%");
+			expect(scoreElement.className).toContain("text-yellow-400");
+		});
+
+		it("should apply yellow color for score of 79", () => {
+			render(<ComplianceScore score={79} />);
+			const scoreElement = screen.getByText("79%");
+			expect(scoreElement.className).toContain("text-yellow-400");
+		});
+
+		it("should apply yellow background for warning scores", () => {
+			const { container } = render(<ComplianceScore score={70} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("bg-yellow-900/30");
+		});
+	});
+
+	describe("Color Coding - Low Score (Critical)", () => {
+		it("should apply red color for score < 60", () => {
+			render(<ComplianceScore score={45} />);
+			const scoreElement = screen.getByText("45%");
+			expect(scoreElement.className).toContain("text-red-400");
+		});
+
+		it("should apply red color for score of 59", () => {
+			render(<ComplianceScore score={59} />);
+			const scoreElement = screen.getByText("59%");
+			expect(scoreElement.className).toContain("text-red-400");
+		});
+
+		it("should apply red color for score of 0", () => {
+			render(<ComplianceScore score={0} />);
+			const scoreElement = screen.getByText("0%");
+			expect(scoreElement.className).toContain("text-red-400");
+		});
+
+		it("should apply red background for critical scores", () => {
+			const { container } = render(<ComplianceScore score={45} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("bg-red-900/30");
+		});
+	});
+
+	describe("Color Coding - No Score", () => {
+		it("should apply secondary color for null score", () => {
+			render(<ComplianceScore score={null} />);
+			const scoreElement = screen.getByText("N/A");
+			expect(scoreElement.className).toContain("text-secondary-400");
+		});
+
+		it("should apply secondary background for null score", () => {
+			const { container } = render(<ComplianceScore score={null} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("bg-secondary-700");
+		});
+	});
+
+	describe("Size Variants", () => {
+		it("should apply small size classes when size is sm", () => {
+			const { container } = render(<ComplianceScore score={85} size="sm" />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("text-sm");
+			expect(wrapper.className).toContain("px-2");
+			expect(wrapper.className).toContain("py-1");
+		});
+
+		it("should apply medium size classes by default", () => {
+			const { container } = render(<ComplianceScore score={85} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("text-base");
+			expect(wrapper.className).toContain("px-3");
+			expect(wrapper.className).toContain("py-1.5");
+		});
+
+		it("should apply medium size classes when size is md", () => {
+			const { container } = render(<ComplianceScore score={85} size="md" />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("text-base");
+			expect(wrapper.className).toContain("px-3");
+		});
+
+		it("should apply large size classes when size is lg", () => {
+			const { container } = render(<ComplianceScore score={85} size="lg" />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("text-lg");
+			expect(wrapper.className).toContain("px-4");
+			expect(wrapper.className).toContain("py-2");
+		});
+	});
+
+	describe("Component Structure", () => {
+		it("should render as an inline-flex container", () => {
+			const { container } = render(<ComplianceScore score={85} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("inline-flex");
+		});
+
+		it("should have rounded-full class for pill shape", () => {
+			const { container } = render(<ComplianceScore score={85} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("rounded-full");
+		});
+
+		it("should render an icon alongside the score", () => {
+			const { container } = render(<ComplianceScore score={85} />);
+			const icon = container.querySelector("svg");
+			expect(icon).toBeInTheDocument();
+		});
+
+		it("should have items-center class for vertical alignment", () => {
+			const { container } = render(<ComplianceScore score={85} />);
+			const wrapper = container.firstChild;
+			expect(wrapper.className).toContain("items-center");
+		});
+	});
+
+	describe("Icon Selection", () => {
+		it("should render shield check icon for high score", () => {
+			const { container } = render(<ComplianceScore score={85} />);
+			const icon = container.querySelector("svg");
+			expect(icon).toBeInTheDocument();
+			// Lucide icons use class attribute, check via classList
+			expect(icon.classList.toString()).toContain("text-green-400");
+		});
+
+		it("should render shield alert icon for warning score", () => {
+			const { container } = render(<ComplianceScore score={70} />);
+			const icon = container.querySelector("svg");
+			expect(icon).toBeInTheDocument();
+			expect(icon.classList.toString()).toContain("text-yellow-400");
+		});
+
+		it("should render shield x icon for critical score", () => {
+			const { container } = render(<ComplianceScore score={45} />);
+			const icon = container.querySelector("svg");
+			expect(icon).toBeInTheDocument();
+			expect(icon.classList.toString()).toContain("text-red-400");
+		});
+
+		it("should render shield question icon for null score", () => {
+			const { container } = render(<ComplianceScore score={null} />);
+			const icon = container.querySelector("svg");
+			expect(icon).toBeInTheDocument();
+			expect(icon.classList.toString()).toContain("text-secondary-400");
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Add frontend component tests for Compliance dashboard page (16 tests)
- Add frontend component tests for ComplianceScore component (32 tests)
- Add API reference documentation (`docs/security-compliance/API-REFERENCE.md`)
- Update README with compliance feature overview

## Test plan
- [x] All backend compliance route tests pass (19 tests)
- [x] All frontend Compliance.test.jsx tests pass (16 tests)
- [x] All frontend ComplianceScore.test.jsx tests pass (32 tests)
- [x] Documentation is complete and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)